### PR TITLE
ReadMe docs Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 Library for creating a custom multiple option selector for React Native
 
 ## Install
+### Step 1
 
 ```shell
 $ npm install rn-multiple-select
@@ -14,6 +15,17 @@ or
 
 ```shell
 $ yarn add rn-multiple-select
+```
+### Step 2
+Install react-native-vector-icons (for icons) package as a dependecy
+
+```shell
+$ npm install --save react-native-vector-icons
+```
+### Step 3
+
+```shell
+$ react-native link react-native-vector-icons
 ```
 
 ## Required Props


### PR DESCRIPTION
@richecr  Please have a look.
Thank you
---
name: Ram
about: The documentation did not have an readme about the dependency package react-native-vector-icons that is been
used in this package, hence it throws an error when you try to use this package.
Added the steps to install the package in the read me
title: Readme Docs (Update)
labels: enhancement,hacktoberfest-accepted,hacktoberfest
assignees: ''

---

#Numero_da_issue

**Descrição do bug/feature:**
The documentation did not have an readme about the dependency package react-native-vector-icons that is been
used in this package, hence it throws an error when you try to use this package. 

**Solução**
 Added the steps to install the required package (react-native-vector-icons) 

**Coisas a serem feitas**

